### PR TITLE
Implement map support and object tokens

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -25,6 +25,7 @@ The library is implemented in the `src/Nomad.Net` folder. It targets **.NET 9.0*
 - `INomadTypeInfoResolver` – abstraction that supplies serializable members for a type. The default implementation uses reflection but a source generator emits a `GeneratedNomadTypeInfoResolver` for AOT scenarios.
 - `NomadValueKind` – enumeration of primitive markers used by the binary writer and reader.
 - Arrays and collections are supported natively and encoded using structural delimiters without length prefixes.
+- Dictionaries are supported using the same structural delimiters with key/value pairs.
 - Attribute types under the `Nomad.Net.Attributes` namespace provide optional metadata:
   - `NomadFieldAttribute` – explicit field identifiers.
   - `NomadIgnoreAttribute` – skip a member.

--- a/src/Nomad.Net/bin/Release/net9.0/Nomad.Net.xml
+++ b/src/Nomad.Net/bin/Release/net9.0/Nomad.Net.xml
@@ -249,6 +249,22 @@
             <param name="type">The target enumerable type.</param>
             <returns>The populated enumerable instance.</returns>
         </member>
+        <member name="M:Nomad.Net.Serialization.NomadSerializer.WriteMap(Nomad.Net.Serialization.INomadWriter,System.Collections.IEnumerable,System.Type)">
+            <summary>
+            Writes a dictionary to the output stream.
+            </summary>
+            <param name="writer">The writer instance.</param>
+            <param name="dictionary">The dictionary to serialize.</param>
+            <param name="type">The runtime type of the dictionary.</param>
+        </member>
+        <member name="M:Nomad.Net.Serialization.NomadSerializer.ReadMap(Nomad.Net.Serialization.INomadReader,System.Type)">
+            <summary>
+            Reads a dictionary from the input stream.
+            </summary>
+            <param name="reader">The reader instance.</param>
+            <param name="type">The runtime dictionary type.</param>
+            <returns>The populated dictionary instance.</returns>
+        </member>
         <member name="T:Nomad.Net.Serialization.NomadSerializerOptions">
             <summary>
             Provides configuration for <see cref="T:Nomad.Net.Serialization.NomadSerializer"/>.


### PR DESCRIPTION
## Summary
- implement structural object tokens and map serialization support
- document dictionary support in implementation guidelines

## Testing
- `dotnet build src/Nomad.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687ad506659083298a2dbd96cad3da1d