### PR TITLE
Extend NomadTypeInfoGenerator to handle structs

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -38,6 +38,7 @@ The library is implemented in the `src/Nomad.Net` folder. It targets **.NET 9.0*
   - `NomadIgnoreAttribute` – skip a member.
   - `NomadMetaAttribute` – custom metadata similar to JSON annotations.
   - `NomadResolverAttribute` – specify a custom `INomadTypeInfoResolver` for a type using `NomadResolver("My.Custom.Resolver")`.
+  - Attributes apply equally to classes and structs so value types can participate in serialization.
 
 ## Using the Library
 

--- a/src/Nomad.Net.Generator.Tests/Nomad.Net.Generator.Tests.csproj
+++ b/src/Nomad.Net.Generator.Tests/Nomad.Net.Generator.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Nomad.Net.Generator/Nomad.Net.Generator.csproj" />
+    <ProjectReference Include="../Nomad.Net/Nomad.Net.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/src/Nomad.Net.Generator.Tests/NomadTypeInfoGeneratorTests.cs
+++ b/src/Nomad.Net.Generator.Tests/NomadTypeInfoGeneratorTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Nomad.Net.Generator;
+using Nomad.Net.Attributes;
+using Xunit;
+
+namespace Nomad.Net.Generator.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="NomadTypeInfoGenerator"/>.
+    /// </summary>
+    public sealed class NomadTypeInfoGeneratorTests
+    {
+        /// <summary>
+        /// Verifies that structs without a custom resolver are included in the generated metadata.
+        /// </summary>
+        [Fact]
+        public void Structs_AreProcessed()
+        {
+            const string source = """
+using Nomad.Net.Attributes;
+
+public struct SampleStruct
+{
+    [NomadField(1)]
+    public int Value;
+}
+
+[NomadResolver("CustomResolver")]
+public struct CustomStruct
+{
+    public int Ignored;
+}
+""";
+
+            string? tpa = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
+            var references = tpa!.Split(Path.PathSeparator)
+                .Select(p => MetadataReference.CreateFromFile(p))
+                .Concat(new[] { MetadataReference.CreateFromFile(typeof(NomadFieldAttribute).Assembly.Location) });
+
+            var compilation = CSharpCompilation.Create(
+                "Tests",
+                new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+                references,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            var generator = new NomadTypeInfoGenerator();
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
+            using var stream = new MemoryStream();
+            var result = outputCompilation.Emit(stream);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+            stream.Position = 0;
+            var assembly = Assembly.Load(stream.ToArray());
+            var resolverType = assembly.GetType("Nomad.Net.Serialization.GeneratedNomadTypeInfoResolver")!;
+            var resolver = Activator.CreateInstance(resolverType)!;
+            var method = resolverType.GetMethod("GetSerializableMembers")!;
+            var members = (IReadOnlyList<MemberInfo>)method.Invoke(resolver, new object?[] { assembly.GetType("SampleStruct")! })!;
+            Assert.Contains(members, m => m.Name == "Value");
+
+            var customMembers = (IReadOnlyList<MemberInfo>)method.Invoke(resolver, new object?[] { assembly.GetType("CustomStruct")! })!;
+            Assert.Empty(customMembers);
+        }
+    }
+}

--- a/src/Nomad.Net.Generator/NomadTypeInfoGenerator.cs
+++ b/src/Nomad.Net.Generator/NomadTypeInfoGenerator.cs
@@ -28,9 +28,14 @@ namespace Nomad.Net.Generator
             foreach (var tree in compilation.SyntaxTrees)
             {
                 var model = compilation.GetSemanticModel(tree);
-                foreach (var typeSyntax in tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>())
+                foreach (var typeSyntax in tree.GetRoot().DescendantNodes().OfType<TypeDeclarationSyntax>())
                 {
                     if (model.GetDeclaredSymbol(typeSyntax) is not INamedTypeSymbol typeSymbol)
+                    {
+                        continue;
+                    }
+
+                    if (typeSymbol.TypeKind != TypeKind.Class && typeSymbol.TypeKind != TypeKind.Struct)
                     {
                         continue;
                     }

--- a/src/Nomad.Net/bin/Release/net9.0/Nomad.Net.xml
+++ b/src/Nomad.Net/bin/Release/net9.0/Nomad.Net.xml
@@ -365,6 +365,21 @@
             A 64-bit floating point value.
             </summary>
         </member>
+        <member name="F:Nomad.Net.Serialization.NomadValueKind.Decimal">
+            <summary>
+            A decimal value.
+            </summary>
+        </member>
+        <member name="F:Nomad.Net.Serialization.NomadValueKind.Char">
+            <summary>
+            A single-byte character.
+            </summary>
+        </member>
+        <member name="F:Nomad.Net.Serialization.NomadValueKind.Rune">
+            <summary>
+            A four-byte Unicode scalar value.
+            </summary>
+        </member>
         <member name="T:Nomad.Net.Serialization.ReflectionNomadTypeInfoResolver">
             <summary>
             Resolves serializable members using runtime reflection.

--- a/src/Nomad.sln
+++ b/src/Nomad.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nomad.Net.Generator", "Noma
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nomad.Net.Tests", "Nomad.Net.Tests\Nomad.Net.Tests.csproj", "{565E60BB-A168-4F1E-94B1-A2BA652049B0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nomad.Net.Generator.Tests", "Nomad.Net.Generator.Tests\Nomad.Net.Generator.Tests.csproj", "{C27A4EF6-BD5F-49BF-893F-16D211872F3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{565E60BB-A168-4F1E-94B1-A2BA652049B0}.Release|x64.Build.0 = Release|Any CPU
 		{565E60BB-A168-4F1E-94B1-A2BA652049B0}.Release|x86.ActiveCfg = Release|Any CPU
 		{565E60BB-A168-4F1E-94B1-A2BA652049B0}.Release|x86.Build.0 = Release|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Debug|x64.Build.0 = Debug|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Debug|x86.Build.0 = Debug|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Release|x64.ActiveCfg = Release|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Release|x64.Build.0 = Release|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Release|x86.ActiveCfg = Release|Any CPU
+		{C27A4EF6-BD5F-49BF-893F-16D211872F3F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- update generator to inspect struct declarations in addition to classes
- document that attributes apply to structs
- add a new `Nomad.Net.Generator.Tests` project
- test struct support for the generator

## Testing
- `dotnet test src/Nomad.sln -c Release`
- `dotnet test src/Nomad.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687b90d0cc5083298f5ce820fba98329