### PR TITLE
Ensure null fields are serialized

### DIFF
--- a/src/Nomad.Net/Serialization/NomadSerializer.cs
+++ b/src/Nomad.Net/Serialization/NomadSerializer.cs
@@ -65,10 +65,12 @@ namespace Nomad.Net.Serialization
                     _ => null,
                 };
 
-                if (memberValue is null)
+                Type memberType = member switch
                 {
-                    continue;
-                }
+                    PropertyInfo pi => pi.PropertyType,
+                    FieldInfo fi => fi.FieldType,
+                    _ => typeof(object),
+                };
 
                 var fieldAttr = member.GetCustomAttribute<NomadFieldAttribute>();
                 if (fieldAttr is null && _options.RequireFieldAttribute)
@@ -84,7 +86,14 @@ namespace Nomad.Net.Serialization
                 int fieldId = fieldAttr?.FieldId ?? member.MetadataToken;
                 writer.WriteFieldHeader(fieldId);
                 writer.WriteToken(NomadToken.NameSeparator);
-                WriteValue(writer, memberValue, memberValue.GetType());
+                if (memberValue is null)
+                {
+                    WriteValue(writer, null, memberType);
+                }
+                else
+                {
+                    WriteValue(writer, memberValue, memberValue.GetType());
+                }
                 first = false;
             }
 


### PR DESCRIPTION
## Summary
- include null members when serializing objects
- test that nullable fields emit null tokens

## Testing
- `dotnet build src/Nomad.Net.Tests/Nomad.Net.Tests.csproj -c Debug`
- `dotnet test src/Nomad.Net.Tests/Nomad.Net.Tests.csproj --no-build -v minimal`
- `dotnet build src/Nomad.Net.Generator.Tests/Nomad.Net.Generator.Tests.csproj -c Debug`
- `dotnet test src/Nomad.Net.Generator.Tests/Nomad.Net.Generator.Tests.csproj --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687b93259f4883298797593539a94183