### PR TITLE
Add Nullable primitive support

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -30,6 +30,8 @@ The library is implemented in the `src/Nomad.Net` folder. It targets **.NET 9.0*
   `NomadValueKind` marker, while arrays and objects are materialized as generic collections.
   Supported kinds include integers, floating point numbers, decimals, booleans, strings,
   binary blobs, single-byte characters and Unicode runes.
+- Nullable primitive types are detected via `Nullable.GetUnderlyingType` and serialized as
+  their underlying kind. A `null` value is encoded using the `NomadValueKind.Null` marker.
 - Binary data is written as raw bytes without a length prefix. Readers compute the length from the enclosing structure or fixed-size type information.
 - Arrays and collections are supported natively and encoded using structural delimiters without length prefixes.
 - Dictionaries are supported using the same structural delimiters with key/value pairs.

--- a/docs/api/Nomad.Net.Tests.xml
+++ b/docs/api/Nomad.Net.Tests.xml
@@ -173,6 +173,11 @@
             Demonstrates behavior when encountering an unknown field.
             </summary>
         </member>
+        <member name="M:Nomad.Net.Tests.ObjectSerializationTests.NullableField_SerializesNull">
+            <summary>
+            Ensures nullable fields are represented as null tokens when serialized.
+            </summary>
+        </member>
         <member name="T:Nomad.Net.Tests.PrimitiveValueTests">
             <summary>
             Tests primitive value serialization.
@@ -241,6 +246,18 @@
             <summary>
             Validates round-trip serialization of <see langword="null"/> values.
             </summary>
+        </member>
+        <member name="M:Nomad.Net.Tests.PrimitiveValueTests.RoundTrip_NullableInt32(System.Nullable{System.Int32})">
+            <summary>
+            Validates round-trip serialization of nullable <see cref="T:System.Int32"/> values.
+            </summary>
+            <param name="value">The value to serialize.</param>
+        </member>
+        <member name="M:Nomad.Net.Tests.PrimitiveValueTests.RoundTrip_NullableBoolean(System.Nullable{System.Boolean})">
+            <summary>
+            Validates round-trip serialization of nullable <see cref="T:System.Boolean"/> values.
+            </summary>
+            <param name="value">The value to serialize.</param>
         </member>
         <member name="T:Nomad.Net.Tests.ReflectionResolverTests">
             <summary>

--- a/src/Nomad.Net.Tests/PrimitiveValueTests.cs
+++ b/src/Nomad.Net.Tests/PrimitiveValueTests.cs
@@ -237,5 +237,48 @@ namespace Nomad.Net.Tests
             var result = reader.ReadValue(typeof(string));
             Assert.Null(result);
         }
+
+        /// <summary>
+        /// Validates round-trip serialization of nullable <see cref="int"/> values.
+        /// </summary>
+        /// <param name="value">The value to serialize.</param>
+        [Theory]
+        [InlineData(10)]
+        [InlineData(null)]
+        public void RoundTrip_NullableInt32(int? value)
+        {
+            using var ms = new MemoryStream();
+            using (var writer = new NomadBinaryWriter(ms))
+            {
+                writer.WriteValue(value, typeof(int?));
+            }
+
+            ms.Position = 0;
+            using var reader = new NomadBinaryReader(ms);
+            var result = reader.ReadValue(typeof(int?));
+            Assert.Equal(value, result);
+        }
+
+        /// <summary>
+        /// Validates round-trip serialization of nullable <see cref="bool"/> values.
+        /// </summary>
+        /// <param name="value">The value to serialize.</param>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        [InlineData(false)]
+        public void RoundTrip_NullableBoolean(bool? value)
+        {
+            using var ms = new MemoryStream();
+            using (var writer = new NomadBinaryWriter(ms))
+            {
+                writer.WriteValue(value, typeof(bool?));
+            }
+
+            ms.Position = 0;
+            using var reader = new NomadBinaryReader(ms);
+            var result = reader.ReadValue(typeof(bool?));
+            Assert.Equal(value, result);
+        }
     }
 }

--- a/src/Nomad.Net/Serialization/NomadBinaryReader.cs
+++ b/src/Nomad.Net/Serialization/NomadBinaryReader.cs
@@ -78,10 +78,21 @@ namespace Nomad.Net.Serialization
         /// <inheritdoc />
         public object? ReadValue(Type type)
         {
+            Type? underlyingType = Nullable.GetUnderlyingType(type);
             byte kind = ReadByteInternal();
             if (kind == (byte)NomadValueKind.Null)
             {
-                return null;
+                if (underlyingType is not null || !type.IsValueType)
+                {
+                    return null;
+                }
+
+                throw new FormatException($"Cannot assign null to non-nullable type {type}");
+            }
+
+            if (underlyingType is not null)
+            {
+                type = underlyingType;
             }
 
             if (type == typeof(object))

--- a/src/Nomad.Net/Serialization/NomadBinaryWriter.cs
+++ b/src/Nomad.Net/Serialization/NomadBinaryWriter.cs
@@ -47,6 +47,18 @@ namespace Nomad.Net.Serialization
         /// <inheritdoc />
         public void WriteValue(object? value, Type type)
         {
+            Type? underlyingType = Nullable.GetUnderlyingType(type);
+            if (underlyingType is not null)
+            {
+                if (value is null)
+                {
+                    _writer.Write((byte)NomadValueKind.Null);
+                    return;
+                }
+
+                type = underlyingType;
+            }
+
             if (value is null)
             {
                 _writer.Write((byte)NomadValueKind.Null);


### PR DESCRIPTION
## Summary
- handle `Nullable<T>` primitives in `NomadBinaryWriter` and `NomadBinaryReader`
- document nullable primitive support
- test `int?` and `bool?` round trips

## Testing
- `dotnet test src/Nomad.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687b96b0a5888329b600087c0c18dc2c