### PR TITLE
Skip unknown fields during deserialization

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -350,9 +350,8 @@ The following conditions **SHOULD** be handled gracefully:
 - Fields present that are marked deprecated
 
 > **Implementation Note:**
-> The reference .NET library included in this repository currently throws a
-> `NotSupportedException` when an unknown field is encountered during
-> deserialization. Future versions are expected to properly skip such fields.
+> The reference .NET library included in this repository skips unknown fields
+> encountered during deserialization.
 
 ### 6.3. Parsing Algorithm
 

--- a/src/Nomad.Net.Tests/ObjectSerializationTests.cs
+++ b/src/Nomad.Net.Tests/ObjectSerializationTests.cs
@@ -48,7 +48,10 @@ namespace Nomad.Net.Tests
 
             ms.Position = 0;
             using var reader = new NomadBinaryReader(ms);
-            Assert.Throws<NotSupportedException>(() => serializer.Deserialize<Person>(reader));
+            var result = serializer.Deserialize<Person>(reader);
+            Assert.NotNull(result);
+            Assert.Equal(v2.Id, result!.Id);
+            Assert.Equal(v2.Name, result.Name);
         }
 
         /// <summary>

--- a/src/Nomad.Net/Serialization/NomadSerializer.cs
+++ b/src/Nomad.Net/Serialization/NomadSerializer.cs
@@ -131,9 +131,8 @@ namespace Nomad.Net.Serialization
 
                 if (!members.TryGetValue(fieldId.Value, out var member))
                 {
-                    // Unknown field - skip value and signal unsupported
+                    // Unknown field - skip its value.
                     ReadValue(reader, typeof(object));
-                    throw new NotSupportedException("Unknown field encountered");
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- ignore unknown fields when deserializing objects
- update test to ensure deserialization succeeds with unknown fields
- clarify specification to note library skips unknown fields

## Testing
- `dotnet test Nomad.Net.Tests/Nomad.Net.Tests.csproj -v minimal`
- `dotnet build src/Nomad.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687b9a555b58832982ae1915dfd2c013