### PR TITLE
Allow 10 byte field header and update tests

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -19,7 +19,7 @@ The library is implemented in the `src/Nomad.Net` folder. It targets **.NET 9.0*
 
 - `INomadWriter` / `INomadReader` – abstractions over the binary format.
 - `NomadBinaryWriter` / `NomadBinaryReader` – default implementations based on `System.IO`.
-  Field headers are encoded as varints and the reader enforces the 10 byte maximum
+  Field headers are encoded as varints and both the writer and reader enforce the 10 byte maximum
   mandated by the specification.
 - `INomadConverter` – extensibility point for custom serialization and deserialization.
 - `NomadSerializerOptions` – configuration container including custom converters and policy settings.

--- a/src/Nomad.Net.Tests/VarintDecodingTests.cs
+++ b/src/Nomad.Net.Tests/VarintDecodingTests.cs
@@ -26,5 +26,39 @@ namespace Nomad.Net.Tests
             using var reader = new NomadBinaryReader(ms);
             Assert.Throws<FormatException>(() => reader.ReadFieldHeader());
         }
+
+        /// <summary>
+        /// Validates the boundary conditions for field header length.
+        /// </summary>
+        [Fact]
+        public void FieldHeader_Boundaries()
+        {
+            // Ten bytes with nine continuation bits should succeed.
+            byte[] valid = new byte[10];
+            for (int i = 0; i < valid.Length - 1; i++)
+            {
+                valid[i] = 0x80;
+            }
+
+            valid[valid.Length - 1] = 0x00;
+
+            using (var ms = new MemoryStream(valid))
+            using (var reader = new NomadBinaryReader(ms))
+            {
+                int? fieldId = reader.ReadFieldHeader();
+                Assert.NotNull(fieldId);
+            }
+
+            // Eleven bytes should throw a format exception.
+            byte[] invalid = new byte[11];
+            for (int i = 0; i < invalid.Length; i++)
+            {
+                invalid[i] = 0x80;
+            }
+
+            using var ms2 = new MemoryStream(invalid);
+            using var reader2 = new NomadBinaryReader(ms2);
+            Assert.Throws<FormatException>(() => reader2.ReadFieldHeader());
+        }
     }
 }

--- a/src/Nomad.Net/Serialization/NomadBinaryWriter.cs
+++ b/src/Nomad.Net/Serialization/NomadBinaryWriter.cs
@@ -26,13 +26,14 @@ namespace Nomad.Net.Serialization
             int count = 0;
             while (value >= 0x80)
             {
-                _writer.Write((byte)(value | 0x80));
-                value >>= 7;
-                count++;
-                if (count >= 9)
+                if (count == 9)
                 {
                     throw new FormatException("Field header exceeds 10 bytes.");
                 }
+
+                _writer.Write((byte)(value | 0x80));
+                value >>= 7;
+                count++;
             }
 
             _writer.Write((byte)value);


### PR DESCRIPTION
## Summary
- enforce 10-byte field headers in `NomadBinaryWriter.WriteFieldHeader`
- cover boundary cases in `VarintDecodingTests`
- document the limit for both reader and writer

## Testing
- `dotnet test src/Nomad.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687b9c96ff1483299f5e7397e383e171