### PR TITLE
Add field ID validation

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -133,7 +133,7 @@ quoted-string = DQUOTE *(CHAR / escaped-char) DQUOTE
 
 #### 3.3.2. Field Identifiers
 
-Field identifiers **MUST** be positive integers (1-2147483647). The value 0 is **RESERVED** and **MUST NOT** be used. Field identifiers **SHOULD** be assigned sequentially starting from 1, but gaps are permitted.
+Field identifiers **MUST** be positive integers (1-2147483647). The value 0 is **RESERVED** and **MUST NOT** be used. Each identifier **MUST** be unique for a given type. Field identifiers **SHOULD** be assigned sequentially starting from 1, but gaps are permitted.
 
 #### 3.3.3. Field Names
 

--- a/docs/api/Nomad.Net.Tests.xml
+++ b/docs/api/Nomad.Net.Tests.xml
@@ -44,6 +44,21 @@
             Verifies round-trip of an array stored as <see cref="T:System.Object"/>.
             </summary>
         </member>
+        <member name="T:Nomad.Net.Tests.FieldIdValidationTests">
+            <summary>
+            Tests validation of field identifiers during serialization.
+            </summary>
+        </member>
+        <member name="M:Nomad.Net.Tests.FieldIdValidationTests.DuplicateIds_Throws">
+            <summary>
+            Ensures duplicate field identifiers cause an exception.
+            </summary>
+        </member>
+        <member name="M:Nomad.Net.Tests.FieldIdValidationTests.ZeroId_Throws">
+            <summary>
+            Ensures a field identifier of zero is rejected.
+            </summary>
+        </member>
         <member name="T:Nomad.Net.Tests.GuidConverter">
             <summary>
             Converter for <see cref="T:System.Guid"/> values using string representation.
@@ -81,6 +96,21 @@
         <member name="P:Nomad.Net.Tests.Models.DictionaryContainer.Values">
             <summary>
             Gets or sets the values keyed by string.
+            </summary>
+        </member>
+        <member name="T:Nomad.Net.Tests.Models.DuplicateFieldIdModel">
+            <summary>
+            Model containing duplicate field identifiers for validation tests.
+            </summary>
+        </member>
+        <member name="P:Nomad.Net.Tests.Models.DuplicateFieldIdModel.Value1">
+            <summary>
+            Gets or sets the first value.
+            </summary>
+        </member>
+        <member name="P:Nomad.Net.Tests.Models.DuplicateFieldIdModel.Value2">
+            <summary>
+            Gets or sets the second value.
             </summary>
         </member>
         <member name="T:Nomad.Net.Tests.Models.GuidContainer">
@@ -156,6 +186,16 @@
         <member name="P:Nomad.Net.Tests.Models.StringArrayContainer.Values">
             <summary>
             Gets or sets the values.
+            </summary>
+        </member>
+        <member name="T:Nomad.Net.Tests.Models.ZeroFieldIdModel">
+            <summary>
+            Model containing a field with an invalid zero identifier.
+            </summary>
+        </member>
+        <member name="P:Nomad.Net.Tests.Models.ZeroFieldIdModel.Value">
+            <summary>
+            Gets or sets the value with an invalid identifier.
             </summary>
         </member>
         <member name="T:Nomad.Net.Tests.ObjectSerializationTests">
@@ -277,6 +317,11 @@
         <member name="M:Nomad.Net.Tests.VarintDecodingTests.FieldHeader_TooLong_Throws">
             <summary>
             Ensures the reader rejects field headers exceeding 10 bytes.
+            </summary>
+        </member>
+        <member name="M:Nomad.Net.Tests.VarintDecodingTests.FieldHeader_Boundaries">
+            <summary>
+            Validates the boundary conditions for field header length.
             </summary>
         </member>
     </members>

--- a/docs/api/Nomad.Net.xml
+++ b/docs/api/Nomad.Net.xml
@@ -265,6 +265,17 @@
             <param name="type">The runtime dictionary type.</param>
             <returns>The populated dictionary instance.</returns>
         </member>
+        <member name="M:Nomad.Net.Serialization.NomadSerializer.ValidateFieldIds(System.Type)">
+            <summary>
+            Ensures the specified type's field identifiers are valid and caches the result.
+            </summary>
+            <param name="type">The type to validate.</param>
+        </member>
+        <member name="M:Nomad.Net.Serialization.NomadSerializer.PrevalidateResolverTypes">
+            <summary>
+            Scans all loaded assemblies using the configured resolver and validates discovered types.
+            </summary>
+        </member>
         <member name="T:Nomad.Net.Serialization.NomadSerializerOptions">
             <summary>
             Provides configuration for <see cref="T:Nomad.Net.Serialization.NomadSerializer"/>.
@@ -283,6 +294,13 @@
         <member name="P:Nomad.Net.Serialization.NomadSerializerOptions.TypeInfoResolver">
             <summary>
             Gets or sets the resolver used to discover serializable members for a type.
+            </summary>
+        </member>
+        <member name="P:Nomad.Net.Serialization.NomadSerializerOptions.ValidateFieldsOnStartup">
+            <summary>
+            Gets or sets a value indicating whether to validate field identifiers during serializer construction.
+            When enabled the resolver is scanned for all available types and <see cref="T:Nomad.Net.Serialization.NomadSerializer"/>
+            will throw if any field identifier is duplicated or less than one.
             </summary>
         </member>
         <member name="T:Nomad.Net.Serialization.NomadToken">

--- a/src/Nomad.Net.Tests/FieldIdValidationTests.cs
+++ b/src/Nomad.Net.Tests/FieldIdValidationTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using Nomad.Net.Serialization;
+using Nomad.Net.Tests.Models;
+using Xunit;
+
+namespace Nomad.Net.Tests
+{
+    /// <summary>
+    /// Tests validation of field identifiers during serialization.
+    /// </summary>
+    public sealed class FieldIdValidationTests
+    {
+        /// <summary>
+        /// Ensures duplicate field identifiers cause an exception.
+        /// </summary>
+        [Fact]
+        public void DuplicateIds_Throws()
+        {
+            var serializer = new NomadSerializer();
+            var model = new DuplicateFieldIdModel { Value1 = 1, Value2 = 2 };
+            using var ms = new MemoryStream();
+            using var writer = new NomadBinaryWriter(ms);
+            Assert.Throws<InvalidOperationException>(() => serializer.Serialize(writer, model));
+        }
+
+        /// <summary>
+        /// Ensures a field identifier of zero is rejected.
+        /// </summary>
+        [Fact]
+        public void ZeroId_Throws()
+        {
+            var serializer = new NomadSerializer();
+            var model = new ZeroFieldIdModel { Value = 5 };
+            using var ms = new MemoryStream();
+            using var writer = new NomadBinaryWriter(ms);
+            Assert.Throws<InvalidOperationException>(() => serializer.Serialize(writer, model));
+        }
+    }
+}

--- a/src/Nomad.Net.Tests/Models/DuplicateFieldIdModel.cs
+++ b/src/Nomad.Net.Tests/Models/DuplicateFieldIdModel.cs
@@ -1,0 +1,22 @@
+namespace Nomad.Net.Tests.Models
+{
+    using Nomad.Net.Attributes;
+
+    /// <summary>
+    /// Model containing duplicate field identifiers for validation tests.
+    /// </summary>
+    public sealed class DuplicateFieldIdModel
+    {
+        /// <summary>
+        /// Gets or sets the first value.
+        /// </summary>
+        [NomadField(1)]
+        public int Value1 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the second value.
+        /// </summary>
+        [NomadField(1)]
+        public int Value2 { get; set; }
+    }
+}

--- a/src/Nomad.Net.Tests/Models/ZeroFieldIdModel.cs
+++ b/src/Nomad.Net.Tests/Models/ZeroFieldIdModel.cs
@@ -1,0 +1,16 @@
+namespace Nomad.Net.Tests.Models
+{
+    using Nomad.Net.Attributes;
+
+    /// <summary>
+    /// Model containing a field with an invalid zero identifier.
+    /// </summary>
+    public sealed class ZeroFieldIdModel
+    {
+        /// <summary>
+        /// Gets or sets the value with an invalid identifier.
+        /// </summary>
+        [NomadField(0)]
+        public int Value { get; set; }
+    }
+}

--- a/src/Nomad.Net/Serialization/NomadSerializerOptions.cs
+++ b/src/Nomad.Net/Serialization/NomadSerializerOptions.cs
@@ -20,5 +20,12 @@ namespace Nomad.Net.Serialization
         /// Gets or sets the resolver used to discover serializable members for a type.
         /// </summary>
         public INomadTypeInfoResolver TypeInfoResolver { get; set; } = new ReflectionNomadTypeInfoResolver();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to validate field identifiers during serializer construction.
+        /// When enabled the resolver is scanned for all available types and <see cref="NomadSerializer"/>
+        /// will throw if any field identifier is duplicated or less than one.
+        /// </summary>
+        public bool ValidateFieldsOnStartup { get; set; }
     }
 }

--- a/src/Nomad.Net/bin/Release/net9.0/Nomad.Net.xml
+++ b/src/Nomad.Net/bin/Release/net9.0/Nomad.Net.xml
@@ -265,6 +265,17 @@
             <param name="type">The runtime dictionary type.</param>
             <returns>The populated dictionary instance.</returns>
         </member>
+        <member name="M:Nomad.Net.Serialization.NomadSerializer.ValidateFieldIds(System.Type)">
+            <summary>
+            Ensures the specified type's field identifiers are valid and caches the result.
+            </summary>
+            <param name="type">The type to validate.</param>
+        </member>
+        <member name="M:Nomad.Net.Serialization.NomadSerializer.PrevalidateResolverTypes">
+            <summary>
+            Scans all loaded assemblies using the configured resolver and validates discovered types.
+            </summary>
+        </member>
         <member name="T:Nomad.Net.Serialization.NomadSerializerOptions">
             <summary>
             Provides configuration for <see cref="T:Nomad.Net.Serialization.NomadSerializer"/>.
@@ -283,6 +294,13 @@
         <member name="P:Nomad.Net.Serialization.NomadSerializerOptions.TypeInfoResolver">
             <summary>
             Gets or sets the resolver used to discover serializable members for a type.
+            </summary>
+        </member>
+        <member name="P:Nomad.Net.Serialization.NomadSerializerOptions.ValidateFieldsOnStartup">
+            <summary>
+            Gets or sets a value indicating whether to validate field identifiers during serializer construction.
+            When enabled the resolver is scanned for all available types and <see cref="T:Nomad.Net.Serialization.NomadSerializer"/>
+            will throw if any field identifier is duplicated or less than one.
             </summary>
         </member>
         <member name="T:Nomad.Net.Serialization.NomadToken">


### PR DESCRIPTION
## Summary
- validate field IDs in `NomadSerializer` and add an option to scan types on startup
- enforce validation when writing objects
- test zero or duplicate field IDs
- document unique field requirement in spec
- update API docs

## Testing
- `dotnet test src/Nomad.Net.Tests/Nomad.Net.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687b9e3cbb74832996aa7fc1cbd7cbac